### PR TITLE
Enable assertions in gradle run task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,4 +43,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }


### PR DESCRIPTION
So that assertions are caught when doing `gradle run`.