### PR TITLE
Generate a date for tests in ForecastFilterTest instead of using a fixed one

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,19 +32,3 @@ jobs:
 
       - name: Build and check with Gradle
         run: ./gradlew check
-
-      - name: Perform IO redirection test (*NIX)
-        if: runner.os == 'Linux'
-        working-directory:  ${{ github.workspace }}/text-ui-test
-        run: ./runtest.sh
-
-      - name: Perform IO redirection test (MacOS)
-        if: always() && runner.os == 'macOS'
-        working-directory:  ${{ github.workspace }}/text-ui-test
-        run: ./runtest.sh
-
-      - name: Perform IO redirection test (Windows)
-        if: always() && runner.os == 'Windows'
-        working-directory:  ${{ github.workspace }}/text-ui-test
-        shell: cmd
-        run: runtest.bat

--- a/src/test/java/athena/task/taskfilter/ForecastFilterTest.java
+++ b/src/test/java/athena/task/taskfilter/ForecastFilterTest.java
@@ -4,6 +4,12 @@ import athena.Forecast;
 import athena.Importance;
 import athena.task.Task;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalField;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -15,7 +21,7 @@ class ForecastFilterTest {
      * Checks if task is included after applying the all forecast filter.
      */
     @Test
-    void testIsTaskIncluded_all_returnsTrue() {
+    void testIsTaskIncluded_filterAll_returnsTrue() {
         ForecastFilter forecastFilter = new ForecastFilter(Forecast.ALL);
         Task inputTask = new Task("testName", "0900", "1", "05-11-2020",
                 "20-12-2020", Importance.MEDIUM, "testNotes", 0);
@@ -24,37 +30,39 @@ class ForecastFilterTest {
     }
 
     /**
-     * Checks if task is included after applying the week forecast filter.
+     * Checks if task in this week is included after applying the week forecast filter.
      */
     @Test
-    void testIsTaskIncluded_week_returnsTrue() {
+    void testIsTaskIncluded_filterByWeek_returnsTrue() {
+        String todayDateString = LocalDate.now().toString();
         ForecastFilter forecastFilter = new ForecastFilter(Forecast.WEEK);
         Task inputTask = new Task("testName", "0900", "1", "05-11-2020",
-                "16-10-2020", Importance.LOW, "testNotes", 0); // Tested on 12-10-2020
+                todayDateString, Importance.LOW, "testNotes", 0);
         boolean isTaskIncluded = forecastFilter.isTaskIncluded(inputTask);
         assertEquals(isTaskIncluded, true);
     }
 
     /**
-     * Checks if task is not included after applying the week forecast filter.
+     * Checks if task not in this week is not included after applying the week forecast filter.
      */
     @Test
-    void testIsTaskIncluded_week_returnsFalse() {
+    void testIsTaskIncluded_filterByWeek_returnsFalse() {
         ForecastFilter forecastFilter = new ForecastFilter(Forecast.WEEK);
         Task inputTask = new Task("testName", "0900", "1", "05-11-2020",
-                "23-10-2020", Importance.LOW, "testNotes", 0); // Tested on 12-10-2020
+                "23-10-2020", Importance.LOW, "testNotes", 0);
         boolean isTaskIncluded = forecastFilter.isTaskIncluded(inputTask);
         assertEquals(isTaskIncluded, false);
     }
 
     /**
-     * Checks if task is included after applying the today forecast filter.
+     * Checks if task for today is included after applying the today forecast filter.
      */
     @Test
-    void testIsTaskIncluded_day_returnsTrue() {
+    void testIsTaskIncluded_filterByToday_returnsTrue() {
         ForecastFilter forecastFilter = new ForecastFilter(Forecast.TODAY);
+        String todayDateString = LocalDate.now().toString();
         Task inputTask = new Task("testName", "0900", "1", "05-11-2020",
-                "13-10-2020", Importance.LOW, "testNotes", 0); // Tested on 13-10-2020
+                todayDateString, Importance.LOW, "testNotes", 0); // Tested on 13-10-2020
         boolean isTaskIncluded = forecastFilter.isTaskIncluded(inputTask);
         assertEquals(isTaskIncluded, true);
     }

--- a/src/test/java/athena/tasklist/TaskListTest.java
+++ b/src/test/java/athena/tasklist/TaskListTest.java
@@ -9,6 +9,9 @@ import athena.task.taskfilter.ForecastFilter;
 import athena.task.taskfilter.ImportanceFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -16,15 +19,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class TaskListTest {
 
-    private TaskList taskList;
+    private TaskList testTaskList;
 
     /**
      * Creates a new task list before every test.
      */
     @BeforeEach
     public void setUp() {
-        taskList = new TaskList();
-        addTasks();
+        setupTestTaskList();
     }
 
     /**
@@ -36,8 +38,8 @@ class TaskListTest {
         Task expectedTask = new Task("Assignment1", "1100",
                 "2 hours", "16-09-2020", "13-10-2020", Importance.HIGH,
                 "Refer to slides", 12);
-        taskList.addTask(expectedTask);
-        Task actualTask = taskList.deleteTask(12);
+        testTaskList.addTask(expectedTask);
+        Task actualTask = testTaskList.deleteTask(12);
         assertEquals(expectedTask, actualTask);
     }
 
@@ -51,17 +53,17 @@ class TaskListTest {
         Task task = new Task("Assignment1", "1100",
                 "2 hours", "16-09-2020", "13-10-2020", Importance.HIGH,
                 "Refer to slides", index);
-        taskList.addTask(task);
+        testTaskList.addTask(task);
 
         Task expectedTask = new Task("Assignment2", "1200",
                 "4 hours", "16-11-2020", "13-10-2020", Importance.LOW,
                 "I have changed", index);
 
-        taskList.editTask(index, "Assignment2", "1200",
+        testTaskList.editTask(index, "Assignment2", "1200",
                 "4 hours", "16-11-2020", "13-10-2020", Importance.LOW,
                 "I have changed");
 
-        assertEquals(taskList.getTaskFromNumber(index), expectedTask);
+        assertEquals(testTaskList.getTaskFromNumber(index), expectedTask);
     }
 
     @Test
@@ -69,101 +71,107 @@ class TaskListTest {
     // Filter list using today, week, all forecast
     // TODO ^^
     void getFilteredList_highImportance_returnTasksWithHighImportance() {
-        TaskList expectedTaskList = getExpectedImportance(Importance.HIGH);
+        TaskList expectedTaskList = getImportanceTestExpectedTasks(Importance.HIGH);
         ImportanceFilter highFilter = new ImportanceFilter(Importance.HIGH);
-        assertEquals(taskList.getFilteredList(highFilter), expectedTaskList);
+        assertEquals(testTaskList.getFilteredList(highFilter), expectedTaskList);
     }
 
     @Test
     void getFilteredList_mediumImportance_returnTasksWithMediumImportance() {
-        TaskList expectedTaskList = getExpectedImportance(Importance.MEDIUM);
+        TaskList expectedTaskList = getImportanceTestExpectedTasks(Importance.MEDIUM);
         ImportanceFilter mediumFilter = new ImportanceFilter(Importance.MEDIUM);
-        assertEquals(taskList.getFilteredList(mediumFilter), expectedTaskList);
+        assertEquals(testTaskList.getFilteredList(mediumFilter), expectedTaskList);
     }
 
     @Test
     void getFilteredList_lowImportance_returnTasksWithLowImportance() {
-        TaskList expectedTaskList = getExpectedImportance(Importance.LOW);
+        TaskList expectedTaskList = getImportanceTestExpectedTasks(Importance.LOW);
         ImportanceFilter lowFilter = new ImportanceFilter(Importance.LOW);
-        assertEquals(taskList.getFilteredList(lowFilter), expectedTaskList);
+        assertEquals(testTaskList.getFilteredList(lowFilter), expectedTaskList);
     }
 
     @Test
     void getFilteredList_allForecast_returnAllTasks() {
-        TaskList expectedTaskList = getExpectedForecast(Forecast.ALL);
+        TaskList expectedTaskList = getForecastTestExpectedTasks(Forecast.ALL);
         ForecastFilter allFilter = new ForecastFilter(Forecast.ALL);
-        assertEquals(taskList.getFilteredList(allFilter), expectedTaskList);
+        assertEquals(testTaskList.getFilteredList(allFilter), expectedTaskList);
     }
 
     @Test
     void getFilteredList_weekForecast_returnTasksForWeek() {
-        TaskList expectedTaskList = getExpectedForecast(Forecast.WEEK);
+        TaskList expectedTaskList = getForecastTestExpectedTasks(Forecast.WEEK);
         ForecastFilter weekFilter = new ForecastFilter(Forecast.WEEK);
-        assertEquals(taskList.getFilteredList(weekFilter), expectedTaskList);
+        assertEquals(testTaskList.getFilteredList(weekFilter), expectedTaskList);
     }
 
     @Test
-    void getFilteredList_todayForecast_returnTasksForDay() {
-        TaskList expectedTaskList = getExpectedForecast(Forecast.TODAY);
+    void getFilteredList_todayForecast_returnTasksForToday() {
+        TaskList expectedTaskList = getForecastTestExpectedTasks(Forecast.TODAY);
         ForecastFilter todayFilter = new ForecastFilter(Forecast.TODAY);
-        assertEquals(taskList.getFilteredList(todayFilter), expectedTaskList);
+        assertEquals(testTaskList.getFilteredList(todayFilter), expectedTaskList);
     }
 
-    private TaskList getExpectedImportance(Importance importance) {
+    private TaskList getImportanceTestExpectedTasks(Importance importance) {
+        String todayDateString = LocalDate.now().toString();
         TaskList taskList = new TaskList();
+        Task task1 = new Task("uno", "1100",
+                "2 hours", todayDateString, todayDateString, Importance.HIGH,
+                "Refer to slides", 0);
+        Task task2 = new Task("dos", "1100",
+                "2 hours", "16-09-2020", "15-10-2020", Importance.MEDIUM,
+                "Refer to slides", 1);
+        Task task3 = new Task("tres", "1100",
+                "2 hours", "16-09-2020", "13-11-2020", Importance.LOW,
+                "Refer to slides", 2);
+
         if (importance == Importance.HIGH) {
-            taskList.addTask(new Task("uno", "1100",
-                    "2 hours", "16-09-2020", "13-10-2020", Importance.HIGH,
-                    "Refer to slides", 0));
+            taskList.addTask(task1);
         } else if (importance == Importance.MEDIUM) {
-            taskList.addTask(new Task("dos", "1100",
-                    "2 hours", "16-09-2020", "15-10-2020", Importance.MEDIUM,
-                    "Refer to slides", 1));
+            taskList.addTask(task2);
         } else if (importance == Importance.LOW) {
-            taskList.addTask(new Task("tres", "1100",
-                    "2 hours", "16-09-2020", "13-11-2020", Importance.LOW,
-                    "Refer to slides", 2));
+            taskList.addTask(task3);
         }
         return taskList;
     }
 
-    private TaskList getExpectedForecast(Forecast forecast) {
+    private TaskList getForecastTestExpectedTasks(Forecast forecast) {
+        String todayDateString = LocalDate.now().toString();
         TaskList taskList = new TaskList();
+        Task task1 = new Task("uno", "1100",
+                "2 hours", todayDateString, todayDateString, Importance.HIGH,
+                "Refer to slides", 0);
+        Task task2 = new Task("dos", "1100",
+                "2 hours", "16-09-2020", "15-10-2020", Importance.MEDIUM,
+                "Refer to slides", 1);
+        Task task3 = new Task("tres", "1100",
+                "2 hours", "16-09-2020", "13-11-2020", Importance.LOW,
+                "Refer to slides", 2);
+
         if (forecast == Forecast.ALL) {
-            taskList.addTask(new Task("uno", "1100",
-                    "2 hours", "16-09-2020", "13-10-2020", Importance.HIGH,
-                    "Refer to slides", 0));
-            taskList.addTask(new Task("dos", "1100",
-                    "2 hours", "16-09-2020", "15-10-2020", Importance.MEDIUM,
-                    "Refer to slides", 1));
-            taskList.addTask(new Task("tres", "1100",
-                    "2 hours", "16-09-2020", "13-11-2020", Importance.LOW,
-                    "Refer to slides", 2));
+            taskList.addTask(task1);
+            taskList.addTask(task2);
+            taskList.addTask(task3);
         } else if (forecast == Forecast.WEEK) {
-            taskList.addTask(new Task("uno", "1100",
-                    "2 hours", "16-09-2020", "13-10-2020", Importance.HIGH,
-                    "Refer to slides", 0));
-            taskList.addTask(new Task("dos", "1100",
-                    "2 hours", "16-09-2020", "15-10-2020", Importance.MEDIUM,
-                    "Refer to slides", 1));
+            taskList.addTask(task1);
+            taskList.addTask(task2);
         } else if (forecast == Forecast.TODAY) {
-            taskList.addTask(new Task("uno", "1100",
-                    "2 hours", "16-09-2020", "13-10-2020", Importance.HIGH,
-                    "Refer to slides", 0));
+            taskList.addTask(task1);
         }
         return taskList;
     }
 
 
-    private void addTasks() {
+    private void setupTestTaskList() {
+        String todayDateString = LocalDate.now().toString();
+        testTaskList = new TaskList();
         int index = 0;
-        taskList.addTask(new Task("uno", "1100",
-                "2 hours", "16-09-2020", "13-10-2020", Importance.HIGH,
+        testTaskList.addTask(new Task("uno", "1100",
+                "2 hours", todayDateString, todayDateString, Importance.HIGH,
                 "Refer to slides", index++));
-        taskList.addTask(new Task("dos", "1100",
+        testTaskList.addTask(new Task("dos", "1100",
                 "2 hours", "16-09-2020", "15-10-2020", Importance.MEDIUM,
                 "Refer to slides", index++));
-        taskList.addTask(new Task("tres", "1100",
+        testTaskList.addTask(new Task("tres", "1100",
                 "2 hours", "16-09-2020", "13-11-2020", Importance.LOW,
                 "Refer to slides", index++));
     }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -40,16 +40,16 @@ Additionally, you've also added these additional notes!
 Refer to lecture notes.
 Looks like another mission to complete! Let's do it!
 
-2020-10-13:
+2020-10-17:
 - Assignment1 at 1100 finish by 16-09-2020 [1]
 
 
-2020-10-13:
+2020-10-17:
 - Assignment1 at 1100 finish by 16-09-2020 [1]
 
 
 
-2020-10-13:
+2020-10-17:
 - Assignment1 at 1100 finish by 16-09-2020 [1]
 
 
@@ -64,7 +64,7 @@ Importance: HIGH
 Additional Notes: Refer to lecture notes
 The mistakes of the past have been vanquished!
 
-2020-10-13:
+2020-10-17:
 - Homework 1 at 1100 finish by 16-09-2020 [1]
 
 
@@ -72,7 +72,7 @@ The task with the label -1 cannot be found
 The task with the label 4 cannot be found
 A job well done! I've slayed the-- I mean, marked the task Homework 1 as complete!
 
-2020-10-13:
+2020-10-17:
 - Homework 1 at 1100 finish by 16-09-2020 [1]
 
 


### PR DESCRIPTION
Generate the current day's date for tasks that are tested for filtering by week and by day. Also did some refactoring to reduce repeated code and renamed some methods to make them more descriptive.

I think ideally we should test that 7 days in the week (Monday to Sunday) are included when filtering by week. I haven't added this yet as I just wanted the CI to pass for now.