### PR TITLE
Storage: Don't set max number because it is handled by tasklist

### DIFF
--- a/src/main/java/athena/Storage.java
+++ b/src/main/java/athena/Storage.java
@@ -76,8 +76,7 @@ public class Storage {
     //TODO: add compatibility for more task attributes
     public TaskList loadTaskListData() {
         File csvFile = new File(filePath);
-        TaskList output = new TaskList();
-        int maxNumber = 0;
+        TaskList loadedTaskList = new TaskList();
         if (csvFile.isFile()) {
             String row;
             BufferedReader csvReader = null;
@@ -88,9 +87,8 @@ public class Storage {
                     for (int i = 0; i < data.length; i++) {
                         data[i] = data[i].replaceAll("]c}", ",");
                     }
-                    output.addTask(Integer.parseInt(data[7]), data[0], data[1], data[2], data[3], data[4],
+                    loadedTaskList.addTask(Integer.parseInt(data[7]), data[0], data[1], data[2], data[3], data[4],
                             Importance.valueOf(data[5].toUpperCase()), data[6], Boolean.parseBoolean(data[8]));
-                    maxNumber = Integer.parseInt(data[7]);
                 }
 
                 csvReader.close();
@@ -102,7 +100,6 @@ public class Storage {
                 ui.printInvalidTask();
             }
         }
-        output.setMaxNumber(maxNumber);
-        return output;
+        return loadedTaskList;
     }
 }

--- a/src/test/java/athena/StorageMaxNumberTest.csv
+++ b/src/test/java/athena/StorageMaxNumberTest.csv
@@ -1,0 +1,10 @@
+Assignment 1,1600,2,6pm,12-12-2020,HIGH,Tough assignment,0,false
+Assignment 2,1600,2,6pm,13-12-2020,MEDIUM,Tough assignment,1,false
+Assignment 3,1600,2,6pm,14-12-2020,LOW,Tough assignment,4,false
+Assignment 4,1600,2,6pm,14-12-2020,MEDIUM,Tough assignment,2,false
+Assignment 5,1600,2,6pm,14-12-2020,HIGH,Tough assignment,9,false
+Assignment 6,1600,2,6pm,15-12-2020,MEDIUM,Tough assignment,3,false
+Assignment 7,1600,2,6pm,15-12-2020,HIGH,Tough assignment,61,false
+Assignment 8,1600,2,6pm,15-12-2020,MEDIUM,Tough assignment,17,false
+Assignment 9,1600,2,6pm,16-12-2020,LOW,Tough assignment,28,false
+Assignment 10,1600,2,6pm,16-12-2020,MEDIUM,Tough assignment,49,false

--- a/src/test/java/athena/StorageTest.java
+++ b/src/test/java/athena/StorageTest.java
@@ -6,6 +6,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -75,5 +76,14 @@ class StorageTest {
         TaskList tester = TestSetup.getCommaTestTaskList();
         assertTrue(tester.equals(taskList));
 
+    }
+
+    @Test
+    void loadTaskListData_scrambledTaskNumbers_correctMaxNumber() {
+        Ui ui = new Ui();
+        Storage storage = new Storage("src/test/java/athena/StorageMaxNumberTest.csv", ui);
+        TaskList taskList;
+        taskList = storage.loadTaskListData();
+        assertEquals(taskList.getMaxNumber(), 61);
     }
 }


### PR DESCRIPTION
Close #124.

`TaskList.addTask` already ensures that `maxNumber` is the largest. We shouldn't need `Storage` to set it.