### PR TITLE
Timetable: Change to use default locale

### DIFF
--- a/src/main/java/athena/timetable/Timetable.java
+++ b/src/main/java/athena/timetable/Timetable.java
@@ -306,7 +306,7 @@ public class Timetable {
      */
     private LocalDate getFirstDayOfWeek() {
         LocalDate now = LocalDate.now();
-        TemporalField field = WeekFields.of(Locale.forLanguageTag("en_SG")).dayOfWeek();
+        TemporalField field = WeekFields.of(Locale.getDefault()).dayOfWeek();
         return now.with(field, 1);
     }
 


### PR DESCRIPTION
Follows ForecastFilter which uses the default locale, otherwise the timezones might be considered differently and the dates might not be the same as expected.