### PR TITLE
Timetable: Remove dependency on TaskFilter classes

### DIFF
--- a/src/main/java/athena/Athena.java
+++ b/src/main/java/athena/Athena.java
@@ -54,10 +54,17 @@ public class Athena {
         Scanner input = new Scanner(System.in);
 
         while (!isExit) {
-            allocator = new TimeAllocator(taskList);
-            allocator.runAllocate();
-            inputString = input.nextLine();
-            isExit = false; //logicManager.execute(inputString);
+            try {
+                allocator = new TimeAllocator(taskList);
+                allocator.runAllocate();
+                inputString = input.nextLine();
+                isExit = logicManager.execute(inputString);
+            } catch (CommandException e) {
+                e.printErrorMessage();
+            } catch (StorageException e) {
+                e.printStackTrace();
+            }
+            continue;
         }
     }
 }

--- a/src/main/java/athena/Athena.java
+++ b/src/main/java/athena/Athena.java
@@ -54,17 +54,10 @@ public class Athena {
         Scanner input = new Scanner(System.in);
 
         while (!isExit) {
-            try {
-                allocator = new TimeAllocator(taskList);
-                allocator.runAllocate();
-                inputString = input.nextLine();
-                isExit = logicManager.execute(inputString);
-            } catch (CommandException e) {
-                e.printErrorMessage();
-            } catch (StorageException e) {
-                e.printStackTrace();
-            }
-            continue;
+            allocator = new TimeAllocator(taskList);
+            allocator.runAllocate();
+            inputString = input.nextLine();
+            isExit = false; //logicManager.execute(inputString);
         }
     }
 }

--- a/src/main/java/athena/logic/commands/ListCommand.java
+++ b/src/main/java/athena/logic/commands/ListCommand.java
@@ -3,11 +3,10 @@ package athena.logic.commands;
 import athena.Forecast;
 import athena.Importance;
 import athena.TaskList;
-import athena.ui.AthenaUi;
 import athena.exceptions.EmptyTaskListException;
-import athena.task.taskfilter.ForecastFilter;
-import athena.task.taskfilter.ImportanceFilter;
 import athena.timetable.Timetable;
+import athena.ui.AthenaUi;
+
 import java.util.Objects;
 
 /**
@@ -42,9 +41,7 @@ public class ListCommand extends Command {
         if (taskList.getTasks().isEmpty()) {
             throw new EmptyTaskListException();
         }
-        ImportanceFilter importanceFilter = new ImportanceFilter(taskImportance);
-        ForecastFilter forecastFilter = new ForecastFilter(taskForecast);
-        Timetable timetable = new Timetable(taskList, importanceFilter, forecastFilter);
+        Timetable timetable = new Timetable(taskList, taskImportance, taskForecast);
         athenaUi.printTimetable(timetable);
     }
 

--- a/src/main/java/athena/task/taskfilter/ForecastFilter.java
+++ b/src/main/java/athena/task/taskfilter/ForecastFilter.java
@@ -18,10 +18,6 @@ public class ForecastFilter extends TaskFilter {
         this.forecast = forecast;
     }
 
-    public Forecast getForecast() {
-        return forecast;
-    }
-
     public ForecastFilter(LocalDate date) {
         this.forecast = Forecast.DAY;
         this.filterDate = date;

--- a/src/main/java/athena/timetable/Timetable.java
+++ b/src/main/java/athena/timetable/Timetable.java
@@ -1,15 +1,14 @@
 package athena.timetable;
 
 import athena.Forecast;
+import athena.Importance;
 import athena.TaskList;
 import athena.common.utils.DateUtils;
 import athena.task.Task;
 import athena.task.taskfilter.ForecastFilter;
 import athena.task.taskfilter.ImportanceFilter;
 
-import java.lang.reflect.Array;
 import java.time.LocalDate;
-import java.time.temporal.TemporalAdjuster;
 import java.time.temporal.TemporalField;
 import java.time.temporal.WeekFields;
 import java.util.ArrayList;
@@ -70,14 +69,15 @@ public class Timetable {
     /**
      * Creates a timetable object from a TaskList, ImportanceFilter and ForecastFilter object.
      *
-     * @param taskList         Task list
-     * @param importanceFilter Filters tasks of a certain importance
-     * @param forecastFilter   Filters tasks based on forecast
+     * @param taskList   Task list
+     * @param importance To filter tasks of a certain importance
+     * @param forecast   To filter tasks based on given forecast
      */
-    public Timetable(TaskList taskList, ImportanceFilter importanceFilter, ForecastFilter forecastFilter) {
+    public Timetable(TaskList taskList, Importance importance, Forecast forecast) {
         assert taskList != null;
-        this.taskList = taskList.getFilteredList(importanceFilter).getFilteredList(forecastFilter);
-        this.forecast = forecastFilter.getForecast();
+        this.taskList = taskList.getFilteredList(new ImportanceFilter(importance))
+                .getFilteredList(new ForecastFilter(forecast));
+        this.forecast = forecast;
         populateTimetable();
     }
 

--- a/src/test/java/athena/timetable/TimetableTest.java
+++ b/src/test/java/athena/timetable/TimetableTest.java
@@ -164,8 +164,7 @@ class TimetableTest {
         days.add(day);
 
         TaskList taskList = TestSetup.getTestTaskList();
-        Timetable timetable = new Timetable(taskList, new ImportanceFilter(Importance.HIGH),
-                new ForecastFilter(Forecast.ALL));
+        Timetable timetable = new Timetable(taskList, Importance.HIGH, Forecast.ALL);
 
         assertTrue(areTimetablesSame(timetable, days));
     }


### PR DESCRIPTION
Now `Timetable` takes in `Importance` and `Forecast` in the constructor instead of their corresponding `TaskFilter` classes. This removes `ListCommand`'s dependency on `TaskFilter`, and also allows `Timetable` to store the `Importance` and `Forecast` values if needed.